### PR TITLE
fixed counts of users on dashboards in LRS, but not very efficiently.

### DIFF
--- a/app/locker/data/dashboards/AdminDashboard.php
+++ b/app/locker/data/dashboards/AdminDashboard.php
@@ -60,7 +60,11 @@ class AdminDashboard extends \app\locker\data\BaseData {
    *
    **/
   public function actorCount(){
-    return \Statement::distinct('statement.actor.mbox')->remember(5)->count();
+    $mbox =  intval( \Statement::distinct('statement.actor.mbox')->remember(5)->get()->count() );
+    $openid =  intval( \Statement::distinct('statement.actor.openid')->remember(5)->get()->count() );
+    $mbox_sha1sum =  intval( \Statement::distinct('statement.actor.mbox_sha1sum')->remember(5)->get()->count() );
+    $account =  intval( \Statement::distinct('statement.actor.account.name')->remember(5)->get()->count() );
+    return ($mbox + $openid + $mbox_sha1sum + $account);
   }
 
   /**

--- a/app/locker/data/dashboards/LrsDashboard.php
+++ b/app/locker/data/dashboards/LrsDashboard.php
@@ -52,19 +52,40 @@ class LrsDashboard extends \app\locker\data\BaseData {
    *
    **/
   public function actorCount(){
-
-    $count = $this->db->statements->aggregate(
+    $count_array = ['mbox' => '', 'openid' => '', 'mbox_sha1sum' => '', 'account' => ''];
+    
+    $count_array['mbox'] = $this->db->statements->aggregate(
               array('$match' => $this->getMatch( $this->lrs )),
               array('$group' => array('_id' => '$statement.actor.mbox')),
               array('$group' => array('_id' => 1, 'count' => array('$sum' => 1)))
               );
+    
+    $count_array['openid'] = $this->db->statements->aggregate(
+            array('$match' => $this->getMatch( $this->lrs )),
+            array('$group' => array('_id' => '$statement.actor.openid')),
+            array('$group' => array('_id' => 1, 'count' => array('$sum' => 1)))
+    );
+    
+    $count_array['mbox_sha1sum'] = $this->db->statements->aggregate(
+            array('$match' => $this->getMatch( $this->lrs )),
+            array('$group' => array('_id' => '$statement.actor.mbox_sha1sum')),
+            array('$group' => array('_id' => 1, 'count' => array('$sum' => 1)))
+    );
+    
+    $count_array['account'] = $this->db->statements->aggregate(
+            array('$match' => $this->getMatch( $this->lrs )),
+            array('$group' => array('_id' => '$statement.actor.account.name')),
+            array('$group' => array('_id' => 1, 'count' => array('$sum' => 1)))
+    );
 
-    if( isset($count['result'][0]) ){
-      return $count['result'][0]['count'];
-    }else{
-      return 0;
+    $summary = 0;
+    foreach ($count_array as $key => $val) {
+        if( isset($val['result'][0]) ){
+          $summary += $val['result'][0]['count'];
+        }
     }
-
+    
+    return $summary;
   }
 
   /**


### PR DESCRIPTION
Hey Ryan,
I noticed that the counts on the dashboard (admin and lrs specific) relies on mbox. I made some updates to count all 4 IFIs, but I'm thinking that there are better ways of doing it?  any ideas?